### PR TITLE
Accept address as authP param

### DIFF
--- a/contracts/TokenBalanceOracle.sol
+++ b/contracts/TokenBalanceOracle.sol
@@ -51,13 +51,14 @@ contract TokenBalanceOracle is AragonApp, IACLOracle {
     /**
     * @notice ACLOracle
     * @dev IACLOracle interface conformance.  If the ACLOracle permissioned function should specify the minimum balance,
-    *      it should be used with the modifier 'authP(SOME_ACL_ROLE, arr(minBalance))'
+    *      it should be used with the modifier 'authP(SOME_ACL_ROLE, arr(receiver, minBalance))'
     */
     function canPerform(address _sender, address, bytes32, uint256[] how) external view returns (bool) {
 
-        uint256 minBalanceLocal = how.length > 0 ? how[0] : minBalance;
-        uint256 senderBalance = token.balanceOf(_sender);
+        address sender = how.length > 0 ? address(how[0]) : _sender;
+        uint256 minBalanceLocal = how.length > 1 ? how[1] : minBalance;
 
+        uint256 senderBalance = token.balanceOf(sender);
         return senderBalance >= minBalanceLocal;
     }
 }

--- a/contracts/TokenBalanceOracle.sol
+++ b/contracts/TokenBalanceOracle.sol
@@ -53,10 +53,10 @@ contract TokenBalanceOracle is AragonApp, IACLOracle {
     * @dev IACLOracle interface conformance.  If the ACLOracle permissioned function should specify the minimum balance,
     *      it should be used with the modifier 'authP(SOME_ACL_ROLE, arr(receiver, minBalance))'
     */
-    function canPerform(address _sender, address, bytes32, uint256[] how) external view returns (bool) {
+    function canPerform(address _sender, address, bytes32, uint256[] _how) external view returns (bool) {
 
-        address sender = how.length > 0 ? address(how[0]) : _sender;
-        uint256 minBalanceLocal = how.length > 1 ? how[1] : minBalance;
+        address sender = _how.length > 0 ? address(_how[0]) : _sender;
+        uint256 minBalanceLocal = _how.length > 1 ? _how[1] : minBalance;
 
         uint256 senderBalance = token.balanceOf(sender);
         return senderBalance >= minBalanceLocal;

--- a/contracts/test/mocks/ExecutionTarget.sol
+++ b/contracts/test/mocks/ExecutionTarget.sol
@@ -25,7 +25,7 @@ contract ExecutionTarget is AragonApp {
     }
 
     function decreaseCounter(uint256 minBalance) external authP(DECREASE_COUNTER_ROLE, arr(msg.sender, minBalance)) {
-        if (counter > 1)
+        if (counter > 0)
             counter -= 1;
     }
 

--- a/contracts/test/mocks/ExecutionTarget.sol
+++ b/contracts/test/mocks/ExecutionTarget.sol
@@ -5,7 +5,8 @@ import "@aragon/os/contracts/apps/AragonApp.sol";
 
 contract ExecutionTarget is AragonApp {
     bytes32 public constant SET_COUNTER_ROLE = keccak256("SET_COUNTER_ROLE");
-    bytes32 public constant EXECUTE_ROLE = keccak256("EXECUTE_ROLE");
+    bytes32 public constant INCREASE_COUNTER_ROLE = keccak256("INCREASE_COUNTER_ROLE");
+    bytes32 public constant DECREASE_COUNTER_ROLE = keccak256("DECREASE_COUNTER_ROLE");
 
     uint public counter;
 
@@ -19,7 +20,13 @@ contract ExecutionTarget is AragonApp {
         counter = x;
     }
 
-    function execute(uint256 balance) external authP(EXECUTE_ROLE, arr(balance)) {
+    function increaseCounter() external authP(INCREASE_COUNTER_ROLE, arr(msg.sender)) {
         counter += 1;
     }
+
+    function decreaseCounter(uint256 minBalance) external authP(DECREASE_COUNTER_ROLE, arr(msg.sender, minBalance)) {
+        if (counter > 1)
+            counter -= 1;
+    }
+
 }


### PR DESCRIPTION
Added back again a check to see if the address was passed as params in the `_how` variable.

This is necessary as otherwise we would have to create individual permissions with the oracle to each account instead of just granting it to `ANY_ENTITY`.

For the general use case this requires for functions behind an ACL Oracle to have it's authP modifier `authP(ROLE, arr(msg.sender))` or `authP(ROLE, arr(msg.sender, minBalance))`

